### PR TITLE
fix link to PDF version

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ The presentation is stored in an odp file, which should be compatible with Libre
 PDF
 ---------------
 
-A PDF version is hosted at Golang Weekly: http://golangweekly.com/files/go_for_pythonistas.pdf . (Note that this version may differ from the current state of this repository).
+A PDF version is hosted at Golang Weekly: http://s3.amazonaws.com/golangweekly/go_for_pythonistas.pdf . (Note that this version may differ from the current state of this repository).
 
 Modifications
 --------------


### PR DESCRIPTION
Wow.  Great article!  I noticed the link to pdf was broken, and found it on golangweekly's s3 bucket.
